### PR TITLE
update `sha256`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
               ghc-api-compat = hself.callHackageDirect {
                 pkg = "ghc-api-compat";
                 ver = "8.10.7";
-                sha256 = "0p3sxpzpnccfm9p3yvi88507kh7zcmmg52nl0z12azlh6yfcipw3";
+                sha256 = "g9/InDeQfiXCB9SK8mpl/8B5QEEobj9uqo4xe//telw=";
               } {};
 
               lsp = hself.lsp_1_2_0_1;


### PR DESCRIPTION
For this request: https://github.com/haskell/haskell-language-server/pull/2180#issuecomment-917697017

Acquired by providing empty sha256 and causing error

```
error: hash mismatch in fixed-output derivation '/nix/store/9nr0z0587zy0g4c1a3v58i4f23f7161g-source.drv':
         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
            got:    sha256-g9/InDeQfiXCB9SK8mpl/8B5QEEobj9uqo4xe//telw=
error: 1 dependencies of derivation 
```